### PR TITLE
update valine to the latest version

### DIFF
--- a/layout/partial/comments.pug
+++ b/layout/partial/comments.pug
@@ -59,7 +59,7 @@ if theme.valine
         a#comments
         #vcomments(style="margin:0 30px;")
         script(src='//cdn1.lncld.net/static/js/3.0.4/av-min.js')
-        script(src='//cdn.jsdelivr.net/gh/xcss/valine@v1.1.7/dist/Valine.min.js' + '?v=' + theme.version)
+        script(src='//cdn.jsdelivr.net/gh/xcss/valine@latest/dist/Valine.min.js')
         script.
           var valine = new Valine({
             el:'#vcomments',


### PR DESCRIPTION
主题原采用的是 Valine v1.1.7，版本落后严重，且不能和其他主题平滑迁移。
此 PR 升级 Valine 到最新版，可以和其他主体平滑迁移 Valine 评论。

注意事项：
升级后原评论会无法显示，这是因为 Valine v1.1.7 对 path 采用的处理方式是先 url_encode，而后续版本则没有 url_encode 这一步。

解决方法：
目前并没有看到 Valine 有提供解决方案，我的解决方式有些笨拙麻烦，是：去 leancloud 中把所有的 url 列全进行 url_decode 替换处理。