### PR TITLE
解决文章详情在移动端，分享按钮变为竖排版的问题。

### DIFF
--- a/source/css/style.css
+++ b/source/css/style.css
@@ -688,8 +688,4 @@ a.btn {
   .footer {
     display: none;
   }
-
-  .share {
-    display: grid;
-  }
 }

--- a/source/css/style.scss
+++ b/source/css/style.scss
@@ -778,8 +778,4 @@ a.btn {
 	.footer{
 		display: none;
 	}
-	.share{
-		display: grid;
-	}
-
 }


### PR DESCRIPTION
涉及文件：source/css/style.css  source/css/style.scss

基本原理：取消了分享按钮的grid布局

### 效果

- 修改前：
![image](https://alextech-1252251443.cos.ap-guangzhou.myqcloud.com/20200706151708.png)

- 修改后
![image](https://alextech-1252251443.cos.ap-guangzhou.myqcloud.com/20200706151800.png)
